### PR TITLE
Add default_sort_value to configuration

### DIFF
--- a/lib/handles/sortable_columns.rb
+++ b/lib/handles/sortable_columns.rb
@@ -55,6 +55,11 @@ module Handles  #:nodoc:
       #   sort
       attr_accessor :sort_param
 
+      # Default sort direction, if params[sort_param] is not given.
+      #
+      #   default_sort_value
+      attr_accessor :default_sort_value
+
       # Sort indicator text. If any of values are empty, indicator is not displayed. Default:
       #
       #  {:asc => "&nbsp;&darr;&nbsp;", :desc => "&nbsp;&uarr;&nbsp;"}
@@ -72,6 +77,7 @@ module Handles  #:nodoc:
           :indicator_text => {:asc => "&nbsp;&darr;&nbsp;", :desc => "&nbsp;&uarr;&nbsp;"},
           :page_param => "page",
           :sort_param => "sort",
+          :default_sort_value => nil
         }
 
         defaults.merge(attrs).each {|k, v| send("#{k}=", v)}
@@ -165,10 +171,12 @@ module Handles  #:nodoc:
       #   <%= sortable_column "Name", :link_class => "SortableLink" %>
       #   <%= sortable_column "Created At", :direction => :asc %>
       def sortable_column(title, options = {})    #:doc:
+         puts 'aaa'
         options = options.dup
         o = {}
         conf = {}
         conf[k = :sort_param] = sortable_columns_config[k]
+        conf[k = :default_sort_value] = sortable_columns_config[k]
         conf[k = :page_param] = sortable_columns_config[k]
         conf[k = :indicator_text] = sortable_columns_config[k]
         conf[k = :indicator_class] = sortable_columns_config[k]
@@ -183,7 +191,8 @@ module Handles  #:nodoc:
         raise "Unknown option(s): #{options.inspect}" if not options.empty?
 
         # Parse sort param.
-        pp = parse_sortable_column_sort_param(params[conf[:sort_param]])
+        sort = params[conf[:sort_param]] || conf[:default_sort_value]
+        pp = parse_sortable_column_sort_param(sort)
 
         css_class = []
         if (s = o[:link_class]).present?
@@ -251,9 +260,11 @@ module Handles  #:nodoc:
       def sortable_column_order(&block)
         conf = {}
         conf[k = :sort_param] = sortable_columns_config[k]
+        conf[k = :default_sort_value] = sortable_columns_config[k]
 
         # Parse sort param.
-        pp = parse_sortable_column_sort_param(params[conf[:sort_param]])
+        sort = params[conf[:sort_param]] || conf[:default_sort_value]
+        pp = parse_sortable_column_sort_param(sort)
 
         order = if block
           column, direction = pp[:column], pp[:direction]

--- a/lib/handles/sortable_columns.rb
+++ b/lib/handles/sortable_columns.rb
@@ -171,7 +171,6 @@ module Handles  #:nodoc:
       #   <%= sortable_column "Name", :link_class => "SortableLink" %>
       #   <%= sortable_column "Created At", :direction => :asc %>
       def sortable_column(title, options = {})    #:doc:
-         puts 'aaa'
         options = options.dup
         o = {}
         conf = {}


### PR DESCRIPTION
Here's a minor enhancement that I found useful:

When the sort parameter is not given, the controller may
specify a default in the configuration object's default_sort_value
member. This is mostly done to allow the sorting links to render
the default sort link with the proper CSS class and indicator when
a page is first loaded.
