### PR TITLE
Add Gemfile that references gemspec to fix Bundler `config.local` issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,14 @@
+PATH
+  remote: .
+  specs:
+    handles_sortable_columns (0.1.4)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  handles_sortable_columns!


### PR DESCRIPTION
While working on the gem locally in another project, I found that Bundler's `config.local` wasn't working. After a bit of digging I found:

https://github.com/bundler/bundler/issues/2911

Adding a Gemfile sorted it for me, so I thought I'd share!
